### PR TITLE
Refactor EPD interface to use dependency injection

### DIFF
--- a/epd1in54_V2.cpp
+++ b/epd1in54_V2.cpp
@@ -71,8 +71,9 @@ Epd::~Epd()
 {
 };
 
-Epd::Epd()
+Epd::Epd(EpdIf* epd_if)
 {
+	this->epd_if = epd_if;
 	reset_pin = RST_PIN;
 	dc_pin = DC_PIN;
 	cs_pin = CS_PIN;
@@ -86,8 +87,8 @@ Epd::Epd()
  */
 void Epd::SendCommand(unsigned char command)
 {
-	DigitalWrite(dc_pin, LOW);
-	SpiTransfer(command);
+	epd_if->DigitalWrite(dc_pin, LOW);
+	epd_if->SpiTransfer(command);
 }
 
 void Epd::Lut(unsigned char* lut)
@@ -102,8 +103,8 @@ void Epd::Lut(unsigned char* lut)
  */
 void Epd::SendData(unsigned char data)
 {
-	DigitalWrite(dc_pin, HIGH);
-	SpiTransfer(data);
+	epd_if->DigitalWrite(dc_pin, HIGH);
+	epd_if->SpiTransfer(data);
 }
 
 /**
@@ -111,16 +112,16 @@ void Epd::SendData(unsigned char data)
  */
 void Epd::WaitUntilIdle(void)
 {
-	while(DigitalRead(busy_pin) == 1) {      //LOW: idle, HIGH: busy
-		DelayMs(100);
+	while(epd_if->DigitalRead(busy_pin) == 1) {      //LOW: idle, HIGH: busy
+		epd_if->DelayMs(100);
 	}
-	DelayMs(200);
+	epd_if->DelayMs(200);
 }
 
-int Epd::HDirInit(void)
+int Epd::HDirInit(bool spi_initialize)
 {
 	/* this calls the peripheral hardware interface, see epdif */
-	if (IfInit() != 0) {
+	if (epd_if->IfInit(spi_initialize) != 0) {
 		return -1;
 	}
 	/* EPD hardware init start */
@@ -169,10 +170,10 @@ int Epd::HDirInit(void)
 	return 0;
 }
 
-int Epd::LDirInit(void)
+int Epd::LDirInit(bool spi_initialize)
 {
 	/* this calls the peripheral hardware interface, see epdif */
-	if (IfInit() != 0) {
+	if (epd_if->IfInit(spi_initialize) != 0) {
 		return -1;
 	}
 	/* EPD hardware init start */
@@ -248,12 +249,12 @@ void Epd::SetLut(unsigned char* lut)
  */
 void Epd::Reset(void)
 {
-	DigitalWrite(reset_pin, HIGH);
-	DelayMs(200);
-	DigitalWrite(reset_pin, LOW);                //module reset
-	DelayMs(10);
-	DigitalWrite(reset_pin, HIGH);
-	DelayMs(200);
+	epd_if->DigitalWrite(reset_pin, HIGH);
+	epd_if->DelayMs(200);
+	epd_if->DigitalWrite(reset_pin, LOW);                //module reset
+	epd_if->DelayMs(10);
+	epd_if->DigitalWrite(reset_pin, HIGH);
+	epd_if->DelayMs(200);
 }
 
 void Epd::Clear(void)
@@ -547,9 +548,9 @@ void Epd::Sleep()
 {
 	SendCommand(0x10); //enter deep sleep
 	SendData(0x01);
-	DelayMs(200);
+	epd_if->DelayMs(200);
 
-	DigitalWrite(reset_pin, LOW);
+	epd_if->DigitalWrite(reset_pin, LOW);
 }
 
 /* END OF FILE */

--- a/include/epd1in54_V2.h
+++ b/include/epd1in54_V2.h
@@ -44,17 +44,19 @@ extern "C" {
 
 #include "epdif.h"
 
-class Epd : EpdIf
+class Epd
 {
+protected:
+	EpdIf* epd_if;
 public:
 	unsigned long width;
 	unsigned long height;
 
-	Epd();
+	Epd(EpdIf* epd_if);
 	~Epd();
 	// int  Init(void);
-	int LDirInit(void);
-	int HDirInit(void);
+	int LDirInit(bool spi_initialize = true);
+	int HDirInit(bool spi_initialize = true);
 	void SendCommand(unsigned char command);
 	void SendData(unsigned char data);
 	void WaitUntilIdle(void);

--- a/include/epd1in54_V2.h
+++ b/include/epd1in54_V2.h
@@ -55,8 +55,8 @@ public:
 	Epd(EpdIf* epd_if);
 	~Epd();
 	// int  Init(void);
-	int LDirInit(bool spi_initialize = true);
-	int HDirInit(bool spi_initialize = true);
+	int LDirInit(bool spi_initialize);
+	int HDirInit(bool spi_initialize);
 	void SendCommand(unsigned char command);
 	void SendData(unsigned char data);
 	void WaitUntilIdle(void);

--- a/include/epdif.h
+++ b/include/epdif.h
@@ -47,15 +47,27 @@ extern "C" {
 
 class EpdIf {
 public:
-    EpdIf(void);
-    ~EpdIf(void);
+    EpdIf(void) {};
+    virtual ~EpdIf(void){};
 
-    static int  IfInit(void);
-    static void DigitalWrite(unsigned int pin, int value); 
-    static int  DigitalRead(unsigned int pin);
-    static void DelayMs(unsigned int delaytime);
-    static void SpiTransfer(unsigned char data);
+    virtual int  IfInit(bool spi_initialize) =0 ;
+    virtual void DigitalWrite(unsigned int pin, int value) =0 ; 
+    virtual int  DigitalRead(unsigned int pin) =0 ;
+    virtual void DelayMs(unsigned int delaytime) =0 ;
+    virtual void SpiTransfer(unsigned char data) =0 ;
 };
+
+class EpdIfDefault : public EpdIf {
+public:
+    int IfInit(bool spi_initialize) override;
+    void DigitalWrite(unsigned int pin, int value) override; 
+    int  DigitalRead(unsigned int pin) override;
+    void DelayMs(unsigned int delaytime) override;
+    void SpiTransfer(unsigned char data) override;
+private:
+    virtual int SpiInit();    
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/epdif.h
+++ b/include/epdif.h
@@ -25,6 +25,8 @@
  * THE SOFTWARE.
  */
 
+#include "driver/spi_master.h"
+
 #ifndef EPDIF_H
 #define EPDIF_H
 
@@ -50,23 +52,28 @@ public:
     EpdIf(void) {};
     virtual ~EpdIf(void){};
 
-    virtual int  IfInit(bool spi_initialize) =0 ;
-    virtual void DigitalWrite(unsigned int pin, int value) =0 ; 
-    virtual int  DigitalRead(unsigned int pin) =0 ;
-    virtual void DelayMs(unsigned int delaytime) =0 ;
-    virtual void SpiTransfer(unsigned char data) =0 ;
+    virtual int  IfInit(bool spi_initialize = true);
+    virtual void DigitalWrite(unsigned int pin, int value); 
+    virtual int  DigitalRead(unsigned int pin);
+    virtual void DelayMs(unsigned int delaytime);
+    virtual void SpiTransfer(unsigned char data);
+protected:
+    spi_device_handle_t spi_handle;
+    virtual int SpiInit();
+    virtual void AddDevice(int cs_pin); // Default to CS_PIN
 };
 
-class EpdIfDefault : public EpdIf {
-public:
-    int IfInit(bool spi_initialize) override;
-    void DigitalWrite(unsigned int pin, int value) override; 
-    int  DigitalRead(unsigned int pin) override;
-    void DelayMs(unsigned int delaytime) override;
-    void SpiTransfer(unsigned char data) override;
-private:
-    virtual int SpiInit();    
-};
+// class EpdIfDefault : public EpdIf {
+// public:
+//     virtual int IfInit(bool spi_initialize);
+//     virtual void DigitalWrite(unsigned int pin, int value); 
+//     virtual int  DigitalRead(unsigned int pin);
+//     virtual void DelayMs(unsigned int delaytime);
+//     virtual void SpiTransfer(unsigned char data);
+// protected:
+//     virtual int SpiInit();
+//     virtual void AddDevice();    
+// };
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Refactored Epd class to accept an EpdIf interface pointer, enabling dependency injection. Updated all hardware access in Epd to use the interface. Split EpdIf into an abstract base class and a concrete EpdIfDefault implementation. Added optional SPI initialization flag to HDirInit and LDirInit methods for more flexible hardware setup.